### PR TITLE
python3 compatibility and some formatting

### DIFF
--- a/securemongoengine/__init__.py
+++ b/securemongoengine/__init__.py
@@ -1,4 +1,4 @@
-import fields
-from fields import *
+from . import fields
+from .fields import *
 
 __all__ = (fields.__all__ )

--- a/securemongoengine/base/__init__.py
+++ b/securemongoengine/base/__init__.py
@@ -1,3 +1,3 @@
 from mongoengine.base.fields import *
 
-from exceptions import *
+from .exceptions import *

--- a/securemongoengine/base/exceptions.py
+++ b/securemongoengine/base/exceptions.py
@@ -1,19 +1,22 @@
 class EncryptionKeyException(Exception):
-	def __init__(self, value=None):
-		if value:
-			self.value = value
-		else:
-			self.value = 'You didn\'t introduce a valid encryption key. Did you forget the key '\
-			'param in the field? or you forgot that AES keys have to be 16, 24 or 32 bytes long?'
-	def __str__(self):
-		return repr(self.value)
+    def __init__(self, value=None):
+        if value:
+            self.value = value
+        else:
+            self.value = 'You didn\'t introduce a valid encryption key. Did you forget the key '\
+            'param in the field? or you forgot that AES keys have to be 16, 24 or 32 bytes long?'
+
+    def __str__(self):
+        return repr(self.value)
+
 
 class CipherModeException(Exception):
-	def __init__(self, value=None):
-		if value:
-			self.value = value
-		else:
-			self.value = 'You didn\'t introduce a valid Cipher mode. Remember that SecureMongoEngine '\
-			'only accepts: CBC, CFB, CTR, OFB and OPENPGP'
-	def __str__(self):
-		return repr(self.value)
+    def __init__(self, value=None):
+        if value:
+            self.value = value
+        else:
+            self.value = 'You didn\'t introduce a valid Cipher mode. Remember that SecureMongoEngine '\
+            'only accepts: CBC, CFB, CTR, OFB and OPENPGP'
+
+    def __str__(self):
+        return repr(self.value)

--- a/securemongoengine/base/fields.py
+++ b/securemongoengine/base/fields.py
@@ -1,6 +1,6 @@
 from mongoengine.base import BaseField
 from Crypto.Cipher import AES
-from exceptions import EncryptionKeyException, CipherModeException
+from .exceptions import EncryptionKeyException, CipherModeException
 import binascii
 
 class EncryptedField(BaseField):

--- a/securemongoengine/base/fields.py
+++ b/securemongoengine/base/fields.py
@@ -4,7 +4,7 @@ from .exceptions import EncryptionKeyException, CipherModeException
 import binascii
 
 class EncryptedField(BaseField):
-    
+
     ''' Constants '''
 
     _AES = 'AES'
@@ -22,7 +22,7 @@ class EncryptedField(BaseField):
     algorithm = _AES # Default algorithm value
     internal_type = None # Internal type of the encrypted value
     mode = AES.MODE_CBC
-    
+
     def __init__(self, algorithm=None, key=None,iv=None,mode=None,**kwargs):
         if algorithm:
             self.algorithm = algorithm
@@ -49,13 +49,13 @@ class EncryptedField(BaseField):
         try:
             value=self.decrypt_value(value)
         except:
-            pass #In case that the value is not encrypted (after decryption for example) 
+            pass #In case that the value is not encrypted (after decryption for example)
         super(EncryptedField, self).__set__(instance, value)
 
     def to_mongo(self,value):
         return self.encrypt_value(str(value))
 
-    def prepare_query_value(self, op, value):        
+    def prepare_query_value(self, op, value):
         return self.encrypt_value(value)
 
     def get_internal_type(self):

--- a/securemongoengine/fields.py
+++ b/securemongoengine/fields.py
@@ -2,7 +2,13 @@ from mongoengine import *
 from .base.fields import EncryptedField
 
 __all__ = [
-    'EncryptedEmailField', 'EncryptedStringField', 'EncryptedIntField', 'EncryptedDecimalField', 'EncryptedFloatField','EncryptedLongField']
+    'EncryptedEmailField',
+    'EncryptedStringField',
+    'EncryptedIntField',
+    'EncryptedDecimalField',
+    'EncryptedFloatField',
+    'EncryptedLongField'
+]
 
 class EncryptedEmailField(EncryptedField,EmailField):
     internal_type = type(EmailField())

--- a/securemongoengine/fields.py
+++ b/securemongoengine/fields.py
@@ -1,5 +1,5 @@
 from mongoengine import *
-from base.fields import EncryptedField
+from .base.fields import EncryptedField
 
 __all__ = [
     'EncryptedEmailField', 'EncryptedStringField', 'EncryptedIntField', 'EncryptedDecimalField', 'EncryptedFloatField','EncryptedLongField']


### PR DESCRIPTION
In python3 when using relative import - need to pass '.' before local module. Else we get error for example:

```
  File "/usr/local/lib/python3.5/site-packages/securemongoengine/__init__.py", line 1, in <module>
    from . import fields
  File "/usr/local/lib/python3.5/site-packages/securemongoengine/fields.py", line 2, in <module>
    from base.fields import EncryptedField
ImportError: No module named 'base'
```
- removed extra spaces, replaced `\t` by 4 spaces in exceptions.py, formatted **all** list in one of **init**.py (it was very long for 1 line)
